### PR TITLE
fix: add dependency to example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "react": "^18.2.0",
+    "react-dex-chart": "^1.0.2",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.7.4",


### PR DESCRIPTION
add's the missing key - resolves #1 